### PR TITLE
UZ-52377: making text be bold in modals

### DIFF
--- a/de/px-common.json
+++ b/de/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionDuration}} Minuten"
                 },
                 "scheduled": {
-                    "warning": "Beachte: Solltest du nicht mehr verfügbar sein zu dieser Zeit, <a href='{{entranceLink}}'>sag' ab</a> oder <a href='{{entranceLink}}'>verschiebe</a> deine Teilnahme umgehend. ",
+                    "warning": "**Beachte:** Solltest du nicht mehr verfügbar sein zu dieser Zeit, <a href='{{entranceLink}}'>sag' ab</a> oder <a href='{{entranceLink}}'>verschiebe</a> deine Teilnahme umgehend. ",
                     "join": "In der Sitzung einloggen",
                     "notice": "Du kannst 10 Minuten vor Beginn der Sitzung einsteigen.",
                     "title": "Hier sind die Details für deine nächste Sitzung",

--- a/de/px-common.json
+++ b/de/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionDuration}} Minuten"
                 },
                 "scheduled": {
-                    "warning": "**Beachte:** Solltest du nicht mehr verfügbar sein zu dieser Zeit, <a href='{{entranceLink}}'>sag' ab</a> oder <a href='{{entranceLink}}'>verschiebe</a> deine Teilnahme umgehend. ",
+                    "warning": "**Beachte:** Solltest du nicht mehr verfügbar sein zu dieser Zeit, [sag' ab]({{entranceLink}}) oder [verschiebe]({{entranceLink}}) deine Teilnahme umgehend. ",
                     "join": "In der Sitzung einloggen",
                     "notice": "Du kannst 10 Minuten vor Beginn der Sitzung einsteigen.",
                     "title": "Hier sind die Details für deine nächste Sitzung",

--- a/en-GB/px-common.json
+++ b/en-GB/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {
-                    "warning": "Note: if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
+                    "warning": "**Note:** if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
                     "join": "Join now",
                     "notice": "You'll be able to join the session 10mins before the starting time.",
                     "title": "Here are the details for your upcoming session",

--- a/en-GB/px-common.json
+++ b/en-GB/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {
-                    "warning": "**Note:** if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
+                    "warning": "**Note:** if you can no longer make this time, please [cancel]({{entranceLink}}) or [reschedule]({{entranceLink}}) your participation as soon as possible.",
                     "join": "Join now",
                     "notice": "You'll be able to join the session 10mins before the starting time.",
                     "title": "Here are the details for your upcoming session",

--- a/en/px-common.json
+++ b/en/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {
-                    "warning": "Note: if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
+                    "warning": "**Note:** if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
                     "join": "Join now",
                     "notice": "You'll be able to join the session 10mins before the starting time.",
                     "title": "Here are the details for your upcoming session",

--- a/en/px-common.json
+++ b/en/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {
-                    "warning": "**Note:** if you can no longer make this time, please <a href='{{entranceLink}}'>cancel</a> or <a href='{{entranceLink}}'>reschedule</a> your participation as soon as possible.",
+                    "warning": "**Note:** if you can no longer make this time, please [cancel]({{entranceLink}}) or [reschedule]({{entranceLink}}) your participation as soon as possible.",
                     "join": "Join now",
                     "notice": "You'll be able to join the session 10mins before the starting time.",
                     "title": "Here are the details for your upcoming session",

--- a/es/px-common.json
+++ b/es/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutos"
                 },
                 "scheduled": {
-                    "warning": "**Nota:** Si por algún motivo no puedes llegar a la sesión, pedimos que <a href='{{entranceLink}}'>canceles</a> o <a href='{{entranceLink}}'>modifiques</a> la hora de tu sesión lo más pronto posible. ",
+                    "warning": "**Nota:** Si por algún motivo no puedes llegar a la sesión, pedimos que [canceles]({{entranceLink}}) o [modifiques]({{entranceLink}}) la hora de tu sesión lo más pronto posible.",
                     "join": "Entrar en la sesión",
                     "notice": "Podrás unirte a la sesión 10 minutos antes de la hora de inicio.",
                     "title": "Aquí están los detalles para tu próxima sesión",

--- a/es/px-common.json
+++ b/es/px-common.json
@@ -169,7 +169,7 @@
                     "min": "{{sessionLength}} minutos"
                 },
                 "scheduled": {
-                    "warning": "Nota: Si por algún motivo no puedes llegar a la sesión, pedimos que <a href='{{entranceLink}}'>canceles</a> o <a href='{{entranceLink}}'>modifiques</a> la hora de tu sesión lo más pronto posible. ",
+                    "warning": "**Nota:** Si por algún motivo no puedes llegar a la sesión, pedimos que <a href='{{entranceLink}}'>canceles</a> o <a href='{{entranceLink}}'>modifiques</a> la hora de tu sesión lo más pronto posible. ",
                     "join": "Entrar en la sesión",
                     "notice": "Podrás unirte a la sesión 10 minutos antes de la hora de inicio.",
                     "title": "Aquí están los detalles para tu próxima sesión",


### PR DESCRIPTION
This makes a certain PO tag have a segment in bold, as per Figma design (it's the "Nota:" towards the bottom of the image).

<img width="543" alt="Screenshot 2022-05-05 at 16 37 00" src="https://user-images.githubusercontent.com/97522442/167356738-c4bb0a46-1b04-40ca-b11b-1e33a9c6f6e1.png">
