### PR TITLE
UZ-52291: update certain employment-related questions

### DIFF
--- a/de/px-common.json
+++ b/de/px-common.json
@@ -159,13 +159,13 @@
                     "description": "Du kannst Zeitfenster ansehen und jenes auswählen, das für dich am günstigsten ist.",
                     "book": "Eine Session reservieren",
                     "modalDescription": "In dieser Studie befindest du dich in einem Live-Videoanruf mit einem UX Forscher,  welcher dich um deine Gedanken und Meinung zu einer digitalen Erfahrung bitten wird. \n\nDiese Session wird ungefähr {{sessionDuration}} Minuten dauern. Du wirst auch wählen können, wann du teilnimmst, basierend auf den verfügbaren Zeitfenstern. ",
-                    "mobileRequired": "",
-                    "smsReminder": "",
-                    "contactUser": "",
+                    "mobileRequired": "Es muss eine Handynummer angegeben werden, um eine Sitzung zu planen",
+                    "smsReminder": "Um eine Erinnerung per SMS zu erhalten",
+                    "contactUser": "Sie zu kontaktieren, falls etwas nicht klappt",
                     "why": "Warum?"
                 },
                 "sessionDuration": {
-                    "title": "Sessionsdauer:",
+                    "title": "Sessionsdauer",
                     "min": "{{sessionDuration}} Minuten"
                 },
                 "scheduled": {

--- a/de/px-demographics.json
+++ b/de/px-demographics.json
@@ -747,9 +747,6 @@
             "ethnicity": {
                 "question": "Welcher Rasse gehört Du an?",
                 "shortName": "Rasse"
-            },
-            "noPhone": {
-                "noPhone": "Ich habe kein Mobiltelefon"
             }
         }
     },

--- a/de/px-demographics.json
+++ b/de/px-demographics.json
@@ -747,6 +747,9 @@
             "ethnicity": {
                 "question": "Welcher Rasse gehört Du an?",
                 "shortName": "Rasse"
+            },
+            "noPhone": {
+                "noPhone": "Ich habe kein Mobiltelefon"
             }
         }
     },

--- a/de/px-demographics.json
+++ b/de/px-demographics.json
@@ -713,9 +713,6 @@
                 "question": "Welcher der folgenden Anbieter ist jener für das Mobiltelefon das Du am häufigsten benützt?",
                 "shortName": "Mobilfunkanbieter für Dein meistgenütztes Mobiltelefon"
             },
-            "noPhone": {
-                "noPhone": "Ich habe kein Mobiltelefon"
-            },
             "companyRevenue": {
                 "question": "Was ist der geschätzte Jahresumsatz Deines Unternehmens?",
                 "shortName": "Geschätzer Jahresumsatz Deines Unternehmens"
@@ -750,6 +747,9 @@
             "ethnicity": {
                 "question": "Welcher Rasse gehört Du an?",
                 "shortName": "Rasse"
+            },
+            "noPhone": {
+                "noPhone": "Ich habe kein Mobiltelefon"
             }
         }
     },

--- a/en-GB/px-common.json
+++ b/en-GB/px-common.json
@@ -165,7 +165,7 @@
                     "why": "Why?"
                 },
                 "sessionDuration": {
-                    "title": "Session duration:",
+                    "title": "Session duration",
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {

--- a/en-GB/px-demographics.json
+++ b/en-GB/px-demographics.json
@@ -379,7 +379,7 @@
                     "shortName": "Work industry"
                 },
                 "jobDepartment": {
-                    "question": "Which department do you primarily work within at your organization?",
+                    "question": "Which department do you primarily work within at your company?",
                     "list": {
                         "admin": "Administration / General Staff",
                         "customer_service": "Customer Service / Client Service",
@@ -441,7 +441,7 @@
                     "shortName": "Departments/products you have influence or decision making authority over regarding spending/purchasing."
                 },
                 "companySize": {
-                    "question": "Approximately how many employees work at your organization (all locations)?",
+                    "question": "Approximately how many employees work at your company (all locations)?",
                     "shortName": "Employees at your organization"
                 }
             },
@@ -715,7 +715,7 @@
             },
             "companyRevenue": {
                 "question": "Approximately what is the annual revenue for your company?",
-                "shortName": "Approximate annual revenue of your organisation"
+                "shortName": "Approximate annual revenue of your company"
             },
             "subscriptions": {
                 "question": "Which of the following services are you subscribed to?",

--- a/en-GB/px-demographics.json
+++ b/en-GB/px-demographics.json
@@ -713,12 +713,9 @@
                 "question": "Which of these is the carrier for the mobile phone you use most often?",
                 "shortName": "Carrier for the mobile phone you use most often"
             },
-            "noPhone": {
-                "noPhone": "I don't have a mobile phone"
-            },
             "companyRevenue": {
-                "question": "Approximately what is the annual revenue for your organization?",
-                "shortName": "Approximate annual revenue of your organization"
+                "question": "Approximately what is the annual revenue for your company?",
+                "shortName": "Approximate annual revenue of your organisation"
             },
             "subscriptions": {
                 "question": "Which of the following services are you subscribed to?",
@@ -750,6 +747,9 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
+            },
+            "noPhone": {
+                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/en-GB/px-demographics.json
+++ b/en-GB/px-demographics.json
@@ -747,6 +747,9 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
+            },
+            "noPhone": {
+                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/en-GB/px-demographics.json
+++ b/en-GB/px-demographics.json
@@ -747,9 +747,6 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
-            },
-            "noPhone": {
-                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/en/px-common.json
+++ b/en/px-common.json
@@ -165,7 +165,7 @@
                     "why": "Why?"
                 },
                 "sessionDuration": {
-                    "title": "Session duration:",
+                    "title": "Session duration",
                     "min": "{{sessionLength}} minutes"
                 },
                 "scheduled": {

--- a/en/px-demographics.json
+++ b/en/px-demographics.json
@@ -747,6 +747,9 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
+            },
+            "noPhone": {
+                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/en/px-demographics.json
+++ b/en/px-demographics.json
@@ -747,9 +747,6 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
-            },
-            "noPhone": {
-                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/en/px-demographics.json
+++ b/en/px-demographics.json
@@ -379,7 +379,7 @@
                     "shortName": "Work industry"
                 },
                 "jobDepartment": {
-                    "question": "Which department do you primarily work within at your organization?",
+                    "question": "Which department do you primarily work within at your company?",
                     "list": {
                         "admin": "Administration / General Staff",
                         "customer_service": "Customer Service / Client Service",
@@ -441,7 +441,7 @@
                     "shortName": "Departments/products you have influence or decision making authority over regarding spending/purchasing."
                 },
                 "companySize": {
-                    "question": "Approximately how many employees work at your organization (all locations)?",
+                    "question": "Approximately how many employees work at your company (all locations)?",
                     "shortName": "Employees at your organization"
                 }
             },
@@ -713,9 +713,6 @@
                 "question": "Which of these is the carrier for the mobile phone you use most often?",
                 "shortName": "Carrier for the mobile phone you use most often"
             },
-            "noPhone": {
-                "noPhone": "I don't have a mobile phone"
-            },
             "companyRevenue": {
                 "question": "Approximately what is the annual revenue for your company?",
                 "shortName": "Approximate annual revenue of your company"
@@ -750,6 +747,9 @@
             "ethnicity": {
                 "question": "Which of the following best represents your racial or ethnic heritage?",
                 "shortName": "Racial or ethnic heritage"
+            },
+            "noPhone": {
+                "noPhone": "I don't have a mobile phone"
             }
         }
     },

--- a/es/px-common.json
+++ b/es/px-common.json
@@ -165,7 +165,7 @@
                     "why": "¿Por qué?"
                 },
                 "sessionDuration": {
-                    "title": "Duración de la sesión:",
+                    "title": "Duración de la sesión",
                     "min": "{{sessionLength}} minutos"
                 },
                 "scheduled": {

--- a/es/px-demographics.json
+++ b/es/px-demographics.json
@@ -747,9 +747,6 @@
             "ethnicity": {
                 "question": "De las siguientes opciones, ¿cuál representa mejor tu origen étnico?",
                 "shortName": "Origen étnico"
-            },
-            "noPhone": {
-                "noPhone": "No tengo teléfono móvil"
             }
         }
     },

--- a/es/px-demographics.json
+++ b/es/px-demographics.json
@@ -713,9 +713,6 @@
                 "question": "De las siguientes operadoras de telefonía móvil, ¿cuál es la que más utilizas?",
                 "shortName": "Operadora móvil del teléfono que más utilizas"
             },
-            "noPhone": {
-                "noPhone": "No tengo teléfono móvil"
-            },
             "companyRevenue": {
                 "question": "Aproximadamente, ¿cuáles son los ingresos anuales de tu compañía / organización?",
                 "shortName": "Ingresos anuales aproximados de tu compañía / organización"
@@ -750,6 +747,9 @@
             "ethnicity": {
                 "question": "De las siguientes opciones, ¿cuál representa mejor tu origen étnico?",
                 "shortName": "Origen étnico"
+            },
+            "noPhone": {
+                "noPhone": "No tengo teléfono móvil"
             }
         }
     },

--- a/es/px-demographics.json
+++ b/es/px-demographics.json
@@ -747,6 +747,9 @@
             "ethnicity": {
                 "question": "De las siguientes opciones, ¿cuál representa mejor tu origen étnico?",
                 "shortName": "Origen étnico"
+            },
+            "noPhone": {
+                "noPhone": "No tengo teléfono móvil"
             }
         }
     },


### PR DESCRIPTION
This updates certain employment-related questions. Also per UX, the colon was removed from the Session details PO tag.

This change is from another task, as the translations were pending:
<img width="517" alt="Screenshot 2022-05-11 at 14 34 53" src="https://user-images.githubusercontent.com/97522442/167851086-b1f0b47e-e9d2-4991-9334-9a852e31e7c0.png">

https://uzjira.atlassian.net/browse/UZ-52291

Related PRs:
https://github.com/IntelliZoomPlatform/db-migrations/pull/536