### PR TITLE
fix: [RAD-10089] Make copyright year dynamic

### DIFF
--- a/da/px-common.json
+++ b/da/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Din mening er vigtig. Bliv betalt for at dele dine oplevelser og få indflydelse på produkter du elsker og holder af.",
             "comma": ",",
             "contactUsLowercaseImperative": "kontakt os",
-            "copyright": "IntelliZoom Panel © 2022. Alle rettigheder forbeholdes.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Alle rettigheder forbeholdes.",
             "edge": "Edge",
             "email": "E-mail",
             "firefox": "Firefox",

--- a/de-AT/px-common.json
+++ b/de-AT/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Deine Meinung zählt. Teile Deine Meinung zu Deinen Lieblings-Produkten mit uns und lasse Dich dafür bezahlen.",
             "comma": ",",
             "contactUsLowercaseImperative": "kontaktiere uns",
-            "copyright": "IntelliZoom Panel © 2022. Alle Rechte vorbehalten.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Alle Rechte vorbehalten.",
             "edge": "Edge",
             "email": "E-Mail",
             "firefox": "Firefox",

--- a/de-CH/px-common.json
+++ b/de-CH/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Deine Meinung zählt. Teile Deine Meinung zu Deinen Lieblings-Produkten mit uns und lasse Dich dafür bezahlen.",
             "comma": ",",
             "contactUsLowercaseImperative": "kontaktiere uns",
-            "copyright": "IntelliZoom Panel © 2022. Alle Rechte vorbehalten.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Alle Rechte vorbehalten.",
             "edge": "Edge",
             "email": "E-Mail",
             "firefox": "Firefox",

--- a/de/px-common.json
+++ b/de/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Deine Meinung zählt. Teile Deine Meinung zu Deinen Lieblings-Produkten mit uns und lasse Dich dafür bezahlen.",
             "comma": ",",
             "contactUsLowercaseImperative": "kontaktiere uns",
-            "copyright": "IntelliZoom Panel © 2022. Alle Rechte vorbehalten.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Alle Rechte vorbehalten.",
             "edge": "Edge",
             "email": "E-Mail",
             "firefox": "Firefox",

--- a/en-GB/px-common.json
+++ b/en-GB/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Your opinion matters. Get paid to share your experiences and make an impact on products you love and care about.",
             "comma": ",",
             "contactUsLowercaseImperative": "contact us",
-            "copyright": "IntelliZoom Panel © 2022. All rights reserved.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. All rights reserved.",
             "edge": "Edge",
             "email": "Email",
             "firefox": "Firefox",

--- a/en/px-common.json
+++ b/en/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Your opinion matters. Get paid to share your experiences and make an impact on products you love and care about.",
             "comma": ",",
             "contactUsLowercaseImperative": "contact us",
-            "copyright": "IntelliZoom Panel © 2022. All rights reserved.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. All rights reserved.",
             "edge": "Edge",
             "email": "Email",
             "firefox": "Firefox",

--- a/es-MX/px-common.json
+++ b/es-MX/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Tu opinión cuenta. \nGana dinero por compartir tus experiencias y ayuda a mejorar los productos que más te gustan e interesan.",
             "comma": ",",
             "contactUsLowercaseImperative": "contáctanos",
-            "copyright": "IntelliZoom Panel © 2022. Todos los derechos reservados.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Todos los derechos reservados.",
             "edge": "Edge",
             "email": "Email",
             "firefox": "Firefox",

--- a/es/px-common.json
+++ b/es/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Tu opinión cuenta. \nGana dinero por compartir tus experiencias y ayuda a mejorar los productos que más te gustan e interesan.",
             "comma": ",",
             "contactUsLowercaseImperative": "contáctanos",
-            "copyright": "IntelliZoom Panel © 2022. Todos los derechos reservados.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Todos los derechos reservados.",
             "edge": "Edge",
             "email": "Email",
             "firefox": "Firefox",

--- a/fr/px-common.json
+++ b/fr/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Votre opinion compte. Gagnez des récompenses en aidant des marques internationales à améliorer leurs produits et leurs expériences digitales.",
             "comma": ",",
             "contactUsLowercaseImperative": "contactez-nous",
-            "copyright": "IntelliZoom Panel © 2022. Tous droits réservés.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Tous droits réservés.",
             "edge": "Edge",
             "email": "E-mail",
             "firefox": "Firefox",

--- a/nl/px-common.json
+++ b/nl/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Jouw mening telt. Laat je betalen om je ervaringen te delen en een impact te hebben op producten waar je van houdt en die je belangrijk vindt.",
             "comma": ",",
             "contactUsLowercaseImperative": "contacteer ons.",
-            "copyright": "ntelliZoom Panel © 2022. Alle rechten voorbehouden.",
+            "copyright": "ntelliZoom Panel © {{currentYear}}. Alle rechten voorbehouden.",
             "edge": "Edge",
             "email": "E-mail",
             "firefox": "Firefox",

--- a/sv/px-common.json
+++ b/sv/px-common.json
@@ -7,7 +7,7 @@
             "claim": "Dina åsikter har betydelse. Få betalt för att dela dina erfarenheter och få inflytande på produkter du älskar och bryr dig om.",
             "comma": ",",
             "contactUsLowercaseImperative": "kontakta oss",
-            "copyright": "IntelliZoom Panel © 2022. Alla rättigheter förbehålls.",
+            "copyright": "IntelliZoom Panel © {{currentYear}}. Alla rättigheter förbehålls.",
             "edge": "Edge",
             "email": "E-post",
             "firefox": "Firefox",


### PR DESCRIPTION
### Description

Make the copyright year dynamic in the page footer.

### Ticket links

https://user-testing.atlassian.net/browse/RAD-10089

### Related PRs

https://github.com/IntelliZoomPlatform/panel-portal-ui/pull/564