### PR TITLE
fix: use current year variable in emails RAD-17895

### DIFF
--- a/da/px-emails.json
+++ b/da/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Hjælp!",
-                "copyright": "IntelliZoom Panel drives af UserZoom Technologies, Inc. © 2019-2022 Alle rettigheder forbeholdes. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel drives af UserZoom Technologies, Inc. © {{currentYear}} Alle rettigheder forbeholdes. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Afmeld vores e-mails",
                 "termsOfService": "Servicevilkår",
                 "privacyPolicy": "Privatlivspolitik",
-                "address": "IntelliZoom Panel drives af UserZoom Technologies, Inc. © 2019-2022 Alle rettigheder forbeholdes. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel drives af UserZoom Technologies, Inc. © {{currentYear}} Alle rettigheder forbeholdes. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Tak, <br> UserZoom Teamet",
                 "help": "Hjælp",
                 "unsubscribeSession": "Hvis du ikke længere vil modtage beskeder om denne forskningssession kan du <a href='{{unsubscribeLink}}'>afmelde dig</a>.",

--- a/de/px-emails.json
+++ b/de/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Hilfe!",
-                "copyright": "IntelliZoom Panel wird betrieben von UserZoom Technologies, Inc. © 2019-2022 Alle Rechte vorbehalten<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel wird betrieben von UserZoom Technologies, Inc. © {{currentYear}} Alle Rechte vorbehalten<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Von unseren E-Mails abmelden",
                 "termsOfService": "Nutzungsbedingungen",
                 "privacyPolicy": "Datenschutzerklärung",
-                "address": "IntelliZoom Panel wird betrieben von UserZoom Technologies, Inc. © 2019-2022 Alle Rechte vorbehalten<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel wird betrieben von UserZoom Technologies, Inc. © {{currentYear}} Alle Rechte vorbehalten<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Vielen Dank, <br> UserZoom Team",
                 "help": "Hilfe!",
                 "unsubscribeSession": "Falls du keine Benachrichtigungen über diese Forschungs-Session mehr erhalten möchtest, klicke  <a href='{{unsubscribeLink}}'>abmelden</a>.",

--- a/en-GB/px-emails.json
+++ b/en-GB/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Help!",
-                "copyright": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © 2019-2022 All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © {{currentYear}} All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Unsubscribe from our emails",
                 "termsOfService": "Terms of Service",
                 "privacyPolicy": "Privacy Policy",
-                "address": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © 2019-2022 All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © {{currentYear}} All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Thank you, <br> UserZoom Team",
                 "help": "Help!",
                 "unsubscribeSession": "If you want to stop receiving notifications about this research session, you can  <a href='{{unsubscribeLink}}'>unsubscribe</a>.",

--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Help!",
-                "copyright": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © 2019-2022 All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © {{currentYear}} All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Unsubscribe from our emails",
                 "termsOfService": "Terms of Service",
                 "privacyPolicy": "Privacy Policy",
-                "address": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © 2019-2022 All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel is operated by UserZoom Technologies, Inc. © {{currentYear}} All rights reserved. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Thank you, <br> UserZoom Team",
                 "help": "Help!",
                 "unsubscribeSession": "If you want to stop receiving notifications about this research session, you can  <a href='{{unsubscribeLink}}'>unsubscribe</a>.",

--- a/es/px-emails.json
+++ b/es/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "¡Ayuda!",
-                "copyright": "IntelliZoom Panel es gestionado por UserZoom Technologies, Inc. © 2019-2022 Todos los derechos reservados.<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel es gestionado por UserZoom Technologies, Inc. © {{currentYear}} Todos los derechos reservados.<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Darme de baja",
                 "termsOfService": "Condiciones del Servicio",
                 "privacyPolicy": "Política de Privacidad",
-                "address": "IntelliZoom Panel es gestionado por UserZoom Technologies, Inc. © 2019-2022 Todos los derechos reservados.<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel es gestionado por UserZoom Technologies, Inc. © {{currentYear}} Todos los derechos reservados.<br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Muchas gracias, <br> Equipo UserZoom",
                 "help": "¡Ayuda!",
                 "unsubscribeSession": "Puedes  <a href='{{unsubscribeLink}}'>darte de baja</a> si quieres dejar de recibir notificaciones sobre esta sesión de investigación.",

--- a/fr/px-emails.json
+++ b/fr/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Besoin d’aide ?",
-                "copyright": "IntelliZoom Panel est exploité par UserZoom Technologies, Inc. © 2019-2022 Tous droits réservés. <br>1801 Broadway, Suite 720, Denver, CO 80202, États-Unis",
+                "copyright": "IntelliZoom Panel est exploité par UserZoom Technologies, Inc. © {{currentYear}} Tous droits réservés. <br>1801 Broadway, Suite 720, Denver, CO 80202, États-Unis",
                 "unsubscribe": "Se désabonner de nos mails",
                 "termsOfService": "Conditions d'utilisation",
                 "privacyPolicy": "Politique de confidentialité",
-                "address": "IntelliZoom Panel est exploité par UserZoom Technologies, Inc. © 2019-2022 Tous droits réservés. <br>1801 Broadway, Suite 720, Denver, CO 80202, États-Unis",
+                "address": "IntelliZoom Panel est exploité par UserZoom Technologies, Inc. © {{currentYear}} Tous droits réservés. <br>1801 Broadway, Suite 720, Denver, CO 80202, États-Unis",
                 "thankYou": "Merci, <br>L'équipe UserZoom",
                 "help": "Besoin d’aide ?",
                 "unsubscribeSession": "Si vous ne souhaitez plus recevoir de notifications concernant cette session, vous pouvez vous <a href='{{unsubscribeLink}}'>désabonner</a>.",

--- a/nl/px-emails.json
+++ b/nl/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Help!",
-                "copyright": "IntelliZoom Panel wordt beheerd door UserZoom Technologies, Inc. © 2019-2022 Alle rechten voorbehouden. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel wordt beheerd door UserZoom Technologies, Inc. © {{currentYear}} Alle rechten voorbehouden. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Afmelden van onze e-mails",
                 "termsOfService": "Servicevoorwaarden",
                 "privacyPolicy": "Privacybeleid",
-                "address": "IntelliZoom Panel wordt beheerd door UserZoom Technologies, Inc. © 2019-2022 Alle rechten voorbehouden. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel wordt beheerd door UserZoom Technologies, Inc. © {{currentYear}} Alle rechten voorbehouden. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Bedankt, <br> UserZoom-team",
                 "help": "Help!",
                 "unsubscribeSession": "Als je geen meldingen meer wilt ontvangen over deze onderzoekssessie, kun je je <a href='{{unsubscribeLink}}'>uitschrijven</a>.",

--- a/sv/px-emails.json
+++ b/sv/px-emails.json
@@ -3,11 +3,11 @@
         "emails": {
             "footer": {
                 "support": "Hjälp!",
-                "copyright": "IntelliZoom Panel drivs av UserZoom Technologies, Inc. © 2019-2022 Alla rättigheter förbehållna. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "copyright": "IntelliZoom Panel drivs av UserZoom Technologies, Inc. © {{currentYear}} Alla rättigheter förbehållna. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "unsubscribe": "Avsluta prenumerationen på våra e-postmeddelanden",
                 "termsOfService": "Tjänstevillkor",
                 "privacyPolicy": "Integritetspolicy",
-                "address": "IntelliZoom Panel drivs av UserZoom Technologies, Inc. © 2019-2022 Alla rättigheter förbehållna. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
+                "address": "IntelliZoom Panel drivs av UserZoom Technologies, Inc. © {{currentYear}} Alla rättigheter förbehållna. <br>1801 Broadway, Suite 720, Denver, CO 80202, USA",
                 "thankYou": "Tack, <br> UserZoom-teamet",
                 "help": "Hjälp!",
                 "unsubscribeSession": "Om du inte längre vill få meddelanden om den här forskningssessionen kan du <a href='{{unsubscribeLink}}'>säga upp prenumerationen</a>.",


### PR DESCRIPTION
### Description

use current year variable in the copyright of the emails

### Ticket links

https://user-testing.atlassian.net/browse/RAD-17895

### Related PRs

https://github.com/IntelliZoomPlatform/px-translations/pull/177