### PR TITLE
fix: use separate tokens for default paypal banner

### DIFF
--- a/en/px-platform.json
+++ b/en/px-platform.json
@@ -471,6 +471,11 @@
             "title": "Sorry, we can’t pay you…",
             "description": "Your PayPal account has been disconnected from IntelliZoom. To be paid and to participate in future studies, your PayPal account must be connected.",
             "cta": "Connect with PayPal"
+          },
+          "notVerified": {
+            "title": "Action needed for PayPal payments",
+            "description": "A connected and verified PayPal account is required to participate in paid research studies. First, go to [How do I verify my PayPal account?](https://www.paypal.com/cshelp/article/how-do-i-verify-my-paypal-account-help434) Once verified, return here and select \"Confirm PayPal verification\".  ",
+            "cta": "Confirm PayPal verification"
           }
         },
         "outcome": {


### PR DESCRIPTION
### Description
We were using the sames tokens as the error page
but the spacing is quite different between the two so we need to use separate tokens.

### Ticket links
[RAD-24754]

### Related PRs
[panel-portal-ui](https://github.com/IntelliZoomPlatform/panel-portal-ui/pull/579)

[RAD-24754]: https://user-testing.atlassian.net/browse/RAD-24754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ