### PR TITLE
feat: translations for recenty activity in panel-manager 

### DIFF
--- a/en/px-panel-management.json
+++ b/en/px-panel-management.json
@@ -334,6 +334,20 @@
         },
         "panelistEditModal": {
             "title": "Edit panelist information"
+        },
+        "invitationTable": {
+            "headers": {
+                "invitedAt": "Date/Time",
+                "studyId": "Study UUID",
+                "Id": "Session UUID",
+                "studyType": "Study Type",
+                "status": "Status",
+                "duration": "Duration"
+            },
+            "noInvitationsFound": "No invitations found for this panelist"
+        },
+        "recentActivity": {
+            "title": "Recent Activity"
         }
     }
 }


### PR DESCRIPTION
### Description
Translations for the new recent activity section in panel manager
We only have english translations for this area as it is internal, so once this is merged we are done

### Ticket links
[RAD-26286]

### Related PRs:
[panel-management-ui](https://github.com/IntelliZoomPlatform/panel-management-ui/pull/206)

[RAD-26286]: https://user-testing.atlassian.net/browse/RAD-26286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ