### PR TITLE
feat: pull translations to get px_emails.unified.sign_up_email.greeting

### DIFF
--- a/da/px-emails.json
+++ b/da/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Aktivere konto",
       "button_microcopy": "Dette link udløber om 24 timer",
       "subject": "Handling påkrævet: aktiver konto",
-      "title": "Aktiver din konto"
+      "title": "Aktiver din konto",
+      "greeting": "Hejsa,"
     },
     "study_complete_email": {
       "body_text": "Vi behandler din betaling for testen {{projectId}} via PayPal til den samme e-mailkonto, som er registreret ved UserTesting. Denne proces tager normalt 14 dage. Belønningen for denne test er {{studyFee}}.",

--- a/da/px-emails.json
+++ b/da/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Privatlivspolitik",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Servicevilkår",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcenter",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Tak <br>UserTesting-holdet"
     },
@@ -479,6 +479,13 @@
       "body_text": "Dette er blot en venlig påmindelse om, at du har en kommende live-samtale:",
       "subject": "Påmindelse: Din live-samtale starter om 30 minutter!",
       "title": "Starter snart: Live-samtale"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Deltag i sessionen:\n{{sessionLink}}\nHvis du ikke længere kan deltage i sessionen på det planlagte tidspunkt, kan du omplanlægge eller annullere via følgende link:\n{{rescheduleLink}}",
+        "fileName": "Live samtalesession",
+        "summary": "Live samtalesession"
+      }
     }
   }
 }

--- a/de/px-emails.json
+++ b/de/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Konto aktivieren",
       "button_microcopy": "Dieser Link läuft in 24 Stunden ab",
       "subject": "Handlung erforderlich: Konto aktivieren",
-      "title": "Aktivieren Sie Ihr Konto"
+      "title": "Aktivieren Sie Ihr Konto",
+      "greeting": "Hallo,"
     },
     "study_complete_email": {
       "body_text": "Wir werden Ihre Zahlung für den Test {{projectId}} über PayPal an das gleiche E-Mail-Konto abwickeln, das bei UserTesting registriert ist. Dieser Vorgang dauert normalerweise 14 Tage. Die Belohnung für diesen Test ist {{studyFee}}.",

--- a/de/px-emails.json
+++ b/de/px-emails.json
@@ -276,11 +276,11 @@
       "copyright": "©UserTesting {{currentYear}}, Alle Rechte vorbehalten.",
       "manage_preferences": "E-Mail-Einstellungen verwalten",
       "privacy_policy": "Datenschutzerklärung",
-      "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
+      "privacy_policy_link": "https://www.usertesting.com/de/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Nutzungsbedingungen",
-      "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
+      "terms_of_service_link": "https://www.usertesting.com/de/privacy-center/terms-of-service-contributor"
     },
     "forgot_password_email": {
       "body_text": "Wir haben eine Anfrage zum Zurücksetzen Ihres Passworts erhalten. Klicken Sie auf die Schaltfläche unten, um ein neues Passwort zu erstellen.",
@@ -298,7 +298,7 @@
         "support_center": "Support-Center",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "Support-Team",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Danke <br>Das Team von UserTesting"
     },
@@ -479,6 +479,13 @@
       "body_text": "Nur eine freundliche Erinnerung an Ihre bevorstehende Live-Diskussion:",
       "subject": "Erinnerung: Ihre Live-Diskussion beginnt in 30 Minuten!",
       "title": "Beginnt demnächst: Live-Diskussion"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Session beitreten: \n{{sessionLink}} \nFalls du an dieser Session nicht mehr zur geplanten Zeit teilnehmen kannst, kannst du sie mit dem folgendem Link verschieben order absagen: \n{{rescheduleLink}}",
+        "fileName": "Live-Gesprächssitzung",
+        "summary": "Live-Gesprächssitzung"
+      }
     }
   }
 }

--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Activate account",
       "button_microcopy": "This link expires in 24 hours",
       "subject": "Action required: Activate account",
-      "title": "Activate your account"
+      "title": "Activate your account",
+      "greeting": "Hey there,"
     },
     "study_complete_email": {
       "body_text": "We’ll process your payment for test {{projectId}} via PayPal to the same email account registered with UserTesting. This process usually takes 14 days. The reward for this test is {{studyFee}}.",
@@ -479,6 +480,13 @@
       "body_text": "This is just a friendly reminder of your upcoming Live Conversation:",
       "subject": "Reminder: Your Live Conversation starts in 30 minutes!",
       "title": "Starting soon: Live Conversation"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Join session:\n{{sessionLink}}\nIf you can no longer attend the session at the scheduled time you can reschedule or cancel it by following this link:\n{{rescheduleLink}}",
+        "fileName": "Live Conversation session",
+        "summary": "Live Conversation session"
+      }
     }
   }
 }

--- a/es/px-emails.json
+++ b/es/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Activa tu cuenta",
       "button_microcopy": "Este enlace caduca en 24 horas",
       "subject": "Acción requerida: Activar cuenta",
-      "title": "Activa tu cuenta"
+      "title": "Activa tu cuenta",
+      "greeting": "Hola,"
     },
     "study_complete_email": {
       "body_text": "Procesaremos tu pago por el test {{projectId}} a través de PayPal a la misma cuenta de correo electrónico registrada en UserTesting. Este proceso suele tardar 14 días. La recompensa por este test es {{studyFee}}.",

--- a/es/px-emails.json
+++ b/es/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Política de Privacidad",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Soporte",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Condiciones del Servicio",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Centro de soporte",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "equipo de soporte",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Gracias, <br>El equipo de UserTesting"
     },
@@ -479,6 +479,13 @@
       "body_text": "Esto es solo un recordatorio de su próxima Conversación en directo:",
       "subject": "Recordatorio: ¡Su Conversación en directo comienza en 30 minutos!",
       "title": "Comienza pronto: Conversación en directo"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Entrar en la sesión:\n{{sessionLink}}\nEn caso que no puedas asistir a la sesión, puedes reprogramarla o cancelarla con el siguiente enlace: \n{{rescheduleLink}}",
+        "fileName": "Sesión de conversación en vivo",
+        "summary": "Sesión de conversación en vivo"
+      }
     }
   }
 }

--- a/fr/px-emails.json
+++ b/fr/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Activer mon compte",
       "button_microcopy": "Ce lien expire dans 24 h",
       "subject": "Action requise : Activer le compte",
-      "title": "Activez votre compte"
+      "title": "Activez votre compte",
+      "greeting": "Bonjour, "
     },
     "study_complete_email": {
       "body_text": "Votre paiement pour le test {{projectId}} sera traité via PayPal en utilisant le même compte de messagerie enregistré auprès de UserTesting. Ce processus nécessite généralement 14 jours d'attente. La récompense pour ce test est de {{studyFee}}.",

--- a/fr/px-emails.json
+++ b/fr/px-emails.json
@@ -276,11 +276,11 @@
       "copyright": "©UserTesting {{currentYear}}, tous droits réservés.",
       "manage_preferences": "Gérer les préférences de messagerie",
       "privacy_policy": "Politique de confidentialité",
-      "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
+      "privacy_policy_link": "https://www.usertesting.com/fr/privacy-center/privacy-policy",
       "support": "Assistance",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Conditions d'utilisation",
-      "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
+      "terms_of_service_link": "https://www.usertesting.com/fr/privacy-center/terms-of-service-contributor"
     },
     "forgot_password_email": {
       "body_text": "Nous avons reçu une demande de réinitialisation de votre mot de passe. Sélectionnez le bouton ci-dessous pour en créer un nouveau.",
@@ -298,7 +298,7 @@
         "support_center": "Centre d'assistance",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "équipe d'assistance",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Merci, <br>L'équipe UserTesting"
     },
@@ -479,6 +479,13 @@
       "body_text": "Ceci n'est qu'un rappel amical de votre prochaine conversation en direct :",
       "subject": "Rappel : Votre conversation en direct commence dans 30 minutes !",
       "title": "Bientôt disponible : conversation en direct"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Rejoignez la session : <br> {{sessionLink}} <br> Si vous ne pouvez plus assister à la session à l'heure prévue, vous pouvez la reprogrammer ou l'annuler en suivant ce lien : <br> {{rescheduleLink}}",
+        "fileName": "Séance de conversation en direct",
+        "summary": "Séance de conversation en direct"
+      }
     }
   }
 }

--- a/nl/px-emails.json
+++ b/nl/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Privacybeleid",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Ondersteuning",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Servicevoorwaarden",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcentrum",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Bedankt, <br>Het UserTesting-team"
     },
@@ -479,6 +479,13 @@
       "body_text": "Dit is een vriendelijke herinnering aan uw komende Livegesprek:",
       "subject": "Reminder: uw Livegesprek begint over 30 minuten!",
       "title": "Begint spoedig: Livegesprek"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Deelnemen aan sessie: \n{{sessionLink}} \nAls u de sessie niet meer kunt bijwonen op de geplande tijd, kunt u deze opnieuw plannen of annuleren via deze link: \n{{recheduleLink}}",
+        "fileName": "Live gesprekssessie",
+        "summary": "Live gesprekssessie"
+      }
     }
   }
 }

--- a/nl/px-emails.json
+++ b/nl/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Activeer account",
       "button_microcopy": "Deze link vervalt over 24 uur",
       "subject": "Actie vereist: Activeer account",
-      "title": "Activeer uw account"
+      "title": "Activeer uw account",
+      "greeting": "Hoi,"
     },
     "study_complete_email": {
       "body_text": "We verwerken uw betaling voor de  {{projectId}}-test via PayPal naar hetzelfde e-mailadres dat  geregistreerd is bij UserTesting. Dit proces duurt normaal gesproken 14 dagen. De beloning voor deze test is {{studyFee}}.",

--- a/sv/px-emails.json
+++ b/sv/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Integritetspolicy",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Tjänstevillkor",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcentret",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Tack, <br>UserTesting-teamet"
     },
@@ -479,6 +479,13 @@
       "body_text": "Detta är bara en vänlig påminnelse om din kommande livekonversation:",
       "subject": "Påminnelse: Din livekonversation börjar om 30 minuter!",
       "title": "Startar snart: Livekonversation"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Anslut till session: \n{{sessionLink}} \nKan du inte längre vara med på sammanträdet på den utsatta tiden kan du ändra schemat eller ställa in sammanträdet på följande länk:\n{{rescheduleLink}}",
+        "fileName": "Live-konversationssession",
+        "summary": "Live-konversationssession"
+      }
     }
   }
 }

--- a/sv/px-emails.json
+++ b/sv/px-emails.json
@@ -376,7 +376,8 @@
       "button": "Aktivera konto",
       "button_microcopy": "Den här länken upphör att gälla om 24 timmar",
       "subject": "Åtgärd krävs: Aktivera konto",
-      "title": "Aktivera ditt konto"
+      "title": "Aktivera ditt konto",
+      "greeting": "Hej,"
     },
     "study_complete_email": {
       "body_text": "Vi kommer att behandla din betalning för testet {{projectId}} via PayPal till samma e-postadress som den som registrerats hos UserTesting. Den här processen tar vanligtvis 14 dagar. Belöningen för det här testet är {{studyFee}}.",


### PR DESCRIPTION
### Description
we want the new token `px_emails.unified.sign_up_email.greeting` for the activiation email in the new onboarding flow where we don't have first names

all other changes are unrelated, we just haven't pulled translations in a while

### Ticket links
[RAD-38861]


[RAD-38861]: https://user-testing.atlassian.net/browse/RAD-38861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ