### PR TITLE
fix: pull translations to get new px_emails tokens

### DIFF
--- a/da/px-emails.json
+++ b/da/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Privatlivspolitik",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Servicevilkår",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcenter",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Tak <br>UserTesting-holdet"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "Vi har slettet din konto og dine oplysninger fra vores system (denne e-mail er den sidste kommunikation, du kommer til at modtage fra os).",
-      "second_body_text": "Hvis du ikke anmodede om dette, kan det skyldes en lang periode uden aktivitet, eller misbrug af vores platform, der resulterede i en overtrædelse af vores {{tjenestevilkår}}.",
+      "second_body_text": "Hvis du ikke anmodede om dette, kan det skyldes en lang periode uden aktivitet, eller misbrug af vores platform, der resulterede i en overtrædelse af vores <a href=\"https://www.usertesting.com/privacy-center/terms-of-service-contributor\">tjenestevilkår</a>.",
       "subject": "Din UserTesting-konto er blevet slettet",
-      "third_body_text": "Hvis du mener, at dette er en fejl, eller hvis du vil have flere oplysninger, bedes du {{kontakte os}} eller besøge vores {{supportcenter}}.",
+      "third_body_text": "Hvis du mener, at dette er en fejl, eller hvis du vil have flere oplysninger, bedes du <a href=\"https://participant-support.usertesting.com/hc/requests/new\">kontakte os</a> eller besøge vores <a href=\"https://participant-support.usertesting.com/hc\">supportcenter</a>.\n",
       "title": "UserTesting-konto slettet"
     },
     "participant_not_paid_email": {
       "advice": "Næste gang skal du sørge for, at din enhed er klar til testen, og at du gør dit bedste for at give feedback i topkvalitet.",
-      "best_practices": "For at undgå, at dette sker igen i fremtiden, bedes du gennemse disse {{best practice-anbefalinger}} i vores supportcenter.",
+      "best_practices": "For at undgå, at dette sker igen i fremtiden, bedes du gennemse disse <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">best practice-anbefalinger</a> i vores supportcenter.",
       "body_text": "Vi beklager at måtte informere dig om, at din deltagelse i testen {{projectId}} ikke er blevet godkendt, og at du ikke modtager belønning for testen.",
       "quality_list": {
         "internet_connection": "Ringe internetforbindelse.",
@@ -367,7 +367,7 @@
         "title": "Almindelige årsager til manglende godkendelse omfatter:",
         "tol": "At ikke sige hvad du tænker"
       },
-      "second_body_text": "Hvis du mener, at dette er en fejl eller gerne vil tage prøvesessionen igen, bedes du kontakte vores {{supportteam}}.  ",
+      "second_body_text": "Hvis du mener, at dette er en fejl eller gerne vil tage prøvesessionen igen, bedes du kontakte vores <a href=\"https://participant-support.usertesting.com/hc/requests/new\">supportteam</a>.",
       "subject": "Prøvesession ikke godkendt",
       "title": "Prøvesession ikke godkendt"
     },
@@ -479,6 +479,13 @@
       "body_text": "Dette er blot en venlig påmindelse om, at du har en kommende live-samtale:",
       "subject": "Påmindelse: Din live-samtale starter om 30 minutter!",
       "title": "Starter snart: Live-samtale"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Deltag i sessionen:\n{{sessionLink}}\nHvis du ikke længere kan deltage i sessionen på det planlagte tidspunkt, kan du omplanlægge eller annullere via følgende link:\n{{rescheduleLink}}",
+        "fileName": "Live samtalesession",
+        "summary": "Live samtalesession"
+      }
     }
   }
 }

--- a/de/px-emails.json
+++ b/de/px-emails.json
@@ -276,11 +276,11 @@
       "copyright": "©UserTesting {{currentYear}}, Alle Rechte vorbehalten.",
       "manage_preferences": "E-Mail-Einstellungen verwalten",
       "privacy_policy": "Datenschutzerklärung",
-      "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
+      "privacy_policy_link": "https://www.usertesting.com/de/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Nutzungsbedingungen",
-      "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
+      "terms_of_service_link": "https://www.usertesting.com/de/privacy-center/terms-of-service-contributor"
     },
     "forgot_password_email": {
       "body_text": "Wir haben eine Anfrage zum Zurücksetzen Ihres Passworts erhalten. Klicken Sie auf die Schaltfläche unten, um ein neues Passwort zu erstellen.",
@@ -298,7 +298,7 @@
         "support_center": "Support-Center",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "Support-Team",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Danke <br>Das Team von UserTesting"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "wir haben Ihr Konto mitsamt Ihren Daten aus unserem System gelöscht (diese E-Mail ist die letzte, die Sie von uns erhalten).",
-      "second_body_text": "Falls Sie diese Aktion nicht angefordert haben, könnte dies daran liegen, dass Sie über einen längeren Zeitraum hinweg inaktiv waren oder unsere Plattform missbräuchlich genutzt und damit gegen unsere {{Nutzungsbedingungen}} verstoßen haben.",
+      "second_body_text": "Falls Sie diese Aktion nicht angefordert haben, könnte dies daran liegen, dass Sie über einen längeren Zeitraum hinweg inaktiv waren oder unsere Plattform missbräuchlich genutzt und damit gegen unsere <a href=\"https://www.usertesting.com/de/privacy-center/terms-of-service-contributor\">Nutzungsbedingungen</a> verstoßen haben.",
       "subject": "Ihr UserTesting-Konto wurde gelöscht",
-      "third_body_text": "Wenn dies Ihrer Meinung nach irrtümlich geschehen ist oder Sie weitere Informationen wünschen, bitte {{kontaktieren Sie uns}} oder besuchen Sie unser {{Hilfe-Center}}.",
+      "third_body_text": "Wenn dies Ihrer Meinung nach irrtümlich geschehen ist oder Sie weitere Informationen wünschen, bitte <a href=\"https://participant-support.usertesting.com/hc/requests/new\">kontaktieren Sie uns</a> oder besuchen Sie unser <a href=\"https://participant-support.usertesting.com/hc\">Hilfe-Center</a>.",
       "title": "UserTesting-Konto gelöscht"
     },
     "participant_not_paid_email": {
       "advice": "Bitte stellen Sie beim nächsten Mal sicher, dass Ihr Gerät für den Test bereit ist, und versuchen Sie, ein qualitativ hochwertiges Feedback zu geben.",
-      "best_practices": "Bitte informieren Sie sich in unserem Hilfe-Center über unsere {{Best-Practice-Empfehlungen}}, um solche Mängel in Zukunft zu vermeiden.",
+      "best_practices": "Bitte informieren Sie sich in unserem Hilfe-Center über unsere <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">Best-Practice-Empfehlungen</a>, um solche Mängel in Zukunft zu vermeiden.",
       "body_text": "Leider müssen wir Ihnen mitteilen, dass Ihre Teilnahme am Test {{projectId}} nicht zugelassen wurde und Sie keine Testvergütung erhalten.",
       "quality_list": {
         "internet_connection": "Ihre Internetverbindung könnte zu schlecht gewesen sein.",
@@ -367,7 +367,7 @@
         "title": "Häufige Gründe für die Nichtgenehmigung sind:",
         "tol": "Gedanken werden nicht laut ausgesprochen"
       },
-      "second_body_text": "Wenn Sie glauben, dass dies ein Fehler war, oder Sie die Übung wiederholen möchten, wenden Sie sich bitte an unser {{Support-Team}}.  ",
+      "second_body_text": "Wenn Sie glauben, dass dies ein Fehler war, oder Sie die Übung wiederholen möchten, wenden Sie sich bitte an unser <a href=\"https://participant-support.usertesting.com/hc/requests/new\">Support-Team</a>.",
       "subject": "Übungseinheit nicht genehmigt",
       "title": "Übungseinheit nicht genehmigt"
     },
@@ -479,6 +479,13 @@
       "body_text": "Nur eine freundliche Erinnerung an Ihre bevorstehende Live-Diskussion:",
       "subject": "Erinnerung: Ihre Live-Diskussion beginnt in 30 Minuten!",
       "title": "Beginnt demnächst: Live-Diskussion"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Session beitreten: \n{{sessionLink}} \nFalls du an dieser Session nicht mehr zur geplanten Zeit teilnehmen kannst, kannst du sie mit dem folgendem Link verschieben order absagen: \n{{rescheduleLink}}",
+        "fileName": "Live-Gesprächssitzung",
+        "summary": "Live-Gesprächssitzung"
+      }
     }
   }
 }

--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "We have deleted your account and information from within our system (this email being the last communication you’ll receive from us).",
-      "second_body_text": "If you did not request this, it may be due to a long period of inactivity or due to a misusage of our platform resulting in a violation of our {{Terms of Service}}.",
+      "second_body_text": "If you did not request this, it may be due to a long period of inactivity or due to a misusage of our platform resulting in a violation of our <a href=\"https://www.usertesting.com/privacy-center/terms-of-service-contributor\">Terms of Service</a>.",
       "subject": "Your UserTesting account has been deleted",
-      "third_body_text": "If you think this is a mistake or would like further information, please {{contact us}} or visit our {{Support Center}}.",
+      "third_body_text": "If you think this is a mistake or would like further information, please <a href=\"https://participant-support.usertesting.com/hc/requests/new\">contact us</a> or visit our <a href=\"https://participant-support.usertesting.com/hc/en-us\">Support Center</a>.\n\n",
       "title": "UserTesting account deleted"
     },
     "participant_not_paid_email": {
       "advice": "Next time, make sure your device is ready for the test and do your best to provide top-quality feedback.",
-      "best_practices": "To avoid this happening again in the future, please review these {{best practice recommendations}} in our Support Center.",
+      "best_practices": "To avoid this happening again in the future, please review these <a href=\"https://participant-support.usertesting.com/hc/en-us/articles/37416051787795-Top-tips-for-a-successful-test\">best practice recommendations</a> in our Support Center.",
       "body_text": "We’re sorry to inform you that your participation in the test {{projectId}} hasn’t been approved and you won’t receive the test’s reward.",
       "quality_list": {
         "internet_connection": "Poor internet connection.",
@@ -367,7 +367,7 @@
         "title": "Some common reasons for not being approved include:",
         "tol": "Not speaking your thoughts out loud"
       },
-      "second_body_text": "If you think this was a mistake, or would like to retake the practice session, please reach out to our {{support team}}.  ",
+      "second_body_text": "If you think this was a mistake, or would like to retake the practice session, please reach out to our <a href=\"https://participant-support.usertesting.com/hc/requests/new\">support team</a>.",
       "subject": "Practice session not approved",
       "title": "Practice session not approved"
     },
@@ -479,6 +479,13 @@
       "body_text": "This is just a friendly reminder of your upcoming Live Conversation:",
       "subject": "Reminder: Your Live Conversation starts in 30 minutes!",
       "title": "Starting soon: Live Conversation"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Join session:\n{{sessionLink}}\nIf you can no longer attend the session at the scheduled time you can reschedule or cancel it by following this link:\n{{rescheduleLink}}",
+        "fileName": "Live Conversation session",
+        "summary": "Live Conversation session"
+      }
     }
   }
 }

--- a/es/px-emails.json
+++ b/es/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Política de Privacidad",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Soporte",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Condiciones del Servicio",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Centro de soporte",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "equipo de soporte",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Gracias, <br>El equipo de UserTesting"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "Hemos eliminado su cuenta y la información de nuestro sistema (este correo electrónico es la última comunicación que recibirá de nosotros).",
-      "second_body_text": "Si no lo ha solicitado, puede deberse a un largo período de inactividad o debido a un uso inadecuado de nuestra plataforma que haya supuesto una violación de nuestros {{Términos de servicio}}.",
+      "second_body_text": "Si no lo ha solicitado, puede deberse a un largo período de inactividad o debido a un uso inadecuado de nuestra plataforma que haya supuesto una violación de nuestros <a href=\"https://www.usertesting.com/privacy-center/terms-of-service-contributor\">Términos de servicio</a>.",
       "subject": "Su cuenta de User Testing ha sido eliminada",
-      "third_body_text": "Si cree que se trata de un error o desea más información, {{póngase en contacto con nosotros}} o visite nuestro {{Centro de asistencia}}.",
+      "third_body_text": "Si cree que se trata de un error o desea más información, <a href=\"https://participant-support.usertesting.com/hc/requests/new\">póngase en contacto con nosotros</a> o visite nuestro <a href=\"https://participant-support.usertesting.com/hc\">Centro de asistencia</a>.",
       "title": "Cuenta UserTesting eliminada"
     },
     "participant_not_paid_email": {
       "advice": "La próxima vez, asegúrese de que su dispositivo está preparado para la prueba y haga todo lo posible para aportar comentarios de la mejor calidad.",
-      "best_practices": "Para evitar que esto vuelva a suceder en el futuro, revise estas {{recomendaciones de mejores prácticas}} en nuestro Centro de asistencia.",
+      "best_practices": "Para evitar que esto vuelva a suceder en el futuro, revise estas <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">recomendaciones de mejores prácticas</a> en nuestro Centro de asistencia.",
       "body_text": "Sentimos informarle de que su participación en la prueba {{projectId}} no ha sido aprobada y no recibirá la recompensa de la prueba.",
       "quality_list": {
         "internet_connection": "Mala conexión a internet.",
@@ -367,7 +367,7 @@
         "title": "Algunas razones comunes por las que no se aprueba son",
         "tol": "No expresar tus pensamientos en voz alta"
       },
-      "second_body_text": "Si crees que se trata de un error, o quieres repetir la sesión de práctica, ponte en contacto con nuestro {{equipo de soporte}}.  ",
+      "second_body_text": "Si crees que se trata de un error, o quieres repetir la sesión de práctica, ponte en contacto con nuestro <a href=\"https://participant-support.usertesting.com/hc/requests/new\">equipo de soporte</a>.",
       "subject": "Sesión de práctica no aprobada",
       "title": "Sesión de práctica no aprobada"
     },
@@ -479,6 +479,13 @@
       "body_text": "Esto es solo un recordatorio de su próxima Conversación en directo:",
       "subject": "Recordatorio: ¡Su Conversación en directo comienza en 30 minutos!",
       "title": "Comienza pronto: Conversación en directo"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Entrar en la sesión:\n{{sessionLink}}\nEn caso que no puedas asistir a la sesión, puedes reprogramarla o cancelarla con el siguiente enlace: \n{{rescheduleLink}}",
+        "fileName": "Sesión de conversación en vivo",
+        "summary": "Sesión de conversación en vivo"
+      }
     }
   }
 }

--- a/fr/px-emails.json
+++ b/fr/px-emails.json
@@ -276,11 +276,11 @@
       "copyright": "©UserTesting {{currentYear}}, tous droits réservés.",
       "manage_preferences": "Gérer les préférences de messagerie",
       "privacy_policy": "Politique de confidentialité",
-      "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
+      "privacy_policy_link": "https://www.usertesting.com/fr/privacy-center/privacy-policy",
       "support": "Assistance",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Conditions d'utilisation",
-      "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
+      "terms_of_service_link": "https://www.usertesting.com/fr/privacy-center/terms-of-service-contributor"
     },
     "forgot_password_email": {
       "body_text": "Nous avons reçu une demande de réinitialisation de votre mot de passe. Sélectionnez le bouton ci-dessous pour en créer un nouveau.",
@@ -298,7 +298,7 @@
         "support_center": "Centre d'assistance",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "équipe d'assistance",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Merci, <br>L'équipe UserTesting"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "Nous avons supprimé votre compte et vos informations au sein de notre système (cet e-mail étant la dernière communication que vous recevrez de notre part).",
-      "second_body_text": "Si vous ne l'avez pas demandé, cela peut être dû à une longue période d'inactivité ou à une mauvaise utilisation de notre plate-forme entraînant une violation de nos {{conditions d'utilisation}}.",
+      "second_body_text": "Si vous ne l'avez pas demandé, cela peut être dû à une longue période d'inactivité ou à une mauvaise utilisation de notre plate-forme entraînant une violation de nos <a href=\"https://www.usertesting.com/fr/privacy-center/terms-of-service-contributor\">conditions d'utilisation</a>. ",
       "subject": "Votre compte UserTesting a été supprimé",
-      "third_body_text": "Si vous pensez qu'il s'agit d'une erreur ou si vous souhaitez obtenir de plus amples informations, veuillez {{nous contacter}} ou visiter notre {{Centre d'assistance}}.",
+      "third_body_text": "Si vous pensez qu'il s'agit d'une erreur ou si vous souhaitez obtenir de plus amples informations, veuillez <a href=\"https://participant-support.usertesting.com/hc/requests/new\">nous contacter</a> ou visiter notre <a href=\"https://participant-support.usertesting.com/hc\">Centre d'assistance</a>.",
       "title": "Compte UserTesting supprimé"
     },
     "participant_not_paid_email": {
       "advice": "La prochaine fois, assurez-vous que votre appareil est prêt pour le test et faites de votre mieux pour fournir une opinion de qualité optimale.",
-      "best_practices": "Pour éviter que cela ne se reproduise à l'avenir, veuillez consulter ces {{recommandations de bonnes pratiques}} dans notre centre d'assistance.",
+      "best_practices": "Pour éviter que cela ne se reproduise à l'avenir, veuillez consulter ces <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">recommandations de bonnes pratiques</a> dans notre centre d'assistance.",
       "body_text": "Nous sommes désolés de vous informer que votre participation au test {{projectId}} n'a pas été approuvée et que vous ne recevrez pas la récompense du test.",
       "quality_list": {
         "internet_connection": "Une mauvaise connexion à l'internet",
@@ -367,7 +367,7 @@
         "title": "L'approbation est généralement refusée pour les raisons suivantes :",
         "tol": "Vous n'avez pas exprimé votre opinion à voix haute"
       },
-      "second_body_text": "Si vous pensez qu'il s'agit d'une erreur ou souhaitez reprendre la session d'essai, veuillez contacter notre {{équipe d'assistance}}.  ",
+      "second_body_text": "Si vous pensez qu'il s'agit d'une erreur ou souhaitez reprendre la session d'essai, veuillez contacter notre <a href=\"https://participant-support.usertesting.com/hc/requests/new\">équipe d'assistance</a>.",
       "subject": "Session d'essai non approuvée",
       "title": "Session d'essai non approuvée"
     },
@@ -479,6 +479,13 @@
       "body_text": "Ceci n'est qu'un rappel amical de votre prochaine conversation en direct :",
       "subject": "Rappel : Votre conversation en direct commence dans 30 minutes !",
       "title": "Bientôt disponible : conversation en direct"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Rejoignez la session : <br> {{sessionLink}} <br> Si vous ne pouvez plus assister à la session à l'heure prévue, vous pouvez la reprogrammer ou l'annuler en suivant ce lien : <br> {{rescheduleLink}}",
+        "fileName": "Séance de conversation en direct",
+        "summary": "Séance de conversation en direct"
+      }
     }
   }
 }

--- a/nl/px-emails.json
+++ b/nl/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Privacybeleid",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Ondersteuning",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Servicevoorwaarden",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcentrum",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Bedankt, <br>Het UserTesting-team"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "We hebben uw account en gegevens uit ons systeem verwijderd (deze e-mail is het laatste bericht dat u van ons ontvangt).",
-      "second_body_text": "Indien u dit niet heeft aangevraagd, kan dit zijn wegens een lange periode van inactiviteit of aan verkeerd gebruik van ons platform dat resulteert in een schending van onze {{Servicevoorwaarden}}.",
+      "second_body_text": "Indien u dit niet heeft aangevraagd, kan dit zijn wegens een lange periode van inactiviteit of aan verkeerd gebruik van ons platform dat resulteert in een schending van onze <a href=\"https://www.usertesting.com/privacy-center/terms-of-service-contributor\">Servicevoorwaarden</a>.",
       "subject": "Uw UserTesting-account is verwijderd",
-      "third_body_text": "Indien u denkt dat dit een fout is of meer gegevens wilt, {{neem dan contact met ons op}} of bezoek ons {{Supportcentrum}}.",
+      "third_body_text": "Indien u denkt dat dit een fout is of meer gegevens wilt, <a href=\"https://participant-support.usertesting.com/hc/requests/new\">neem dan contact met ons op</a> of bezoek ons <a href=\"https://participant-support.usertesting.com/hc\">Supportcentrum</a>.",
       "title": "UserTesting-account verwijderd"
     },
     "participant_not_paid_email": {
       "advice": "Zorg er de volgende keer voor dat uw apparaat klaar is voor de test en doe uw best om feedback van topkwaliteit te leveren.",
-      "best_practices": "Om ervoor te zorgen dat dit in de toekomst niet weer gebeurt: raadpleeg deze {{aanbevelingen best practice}} in ons Support Center.",
+      "best_practices": "Om ervoor te zorgen dat dit in de toekomst niet weer gebeurt: raadpleeg deze <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">aanbevelingen best practice</a> in ons Support Center.",
       "body_text": "We moeten u helaas meedelen dat uw deelname aan test {{projectId}} niet is goedgekeurd en u niet voor de beloning in aanmerking komt.",
       "quality_list": {
         "internet_connection": "Slechte internetverbinding",
@@ -367,7 +367,7 @@
         "title": "Enkele veelvoorkomende redenen waarom uw aanvraag niet  goedgekeurd is, zijn:",
         "tol": "Uw gedachten niet hardop uitspreken"
       },
-      "second_body_text": "Als u denkt dat dit een vergissing  is, of als u de oefensessie opnieuw wilt doen, neem dan contact op met ons {{supportteam}}.  ",
+      "second_body_text": "Als u denkt dat dit een vergissing  is, of als u de oefensessie opnieuw wilt doen, neem dan contact op met ons <a href=\"https://participant-support.usertesting.com/hc/requests/new\">supportteam</a>.",
       "subject": "Oefensessie afgekeurd",
       "title": "Oefensessie afgekeurd"
     },
@@ -479,6 +479,13 @@
       "body_text": "Dit is een vriendelijke herinnering aan uw komende Livegesprek:",
       "subject": "Reminder: uw Livegesprek begint over 30 minuten!",
       "title": "Begint spoedig: Livegesprek"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Deelnemen aan sessie: \n{{sessionLink}} \nAls u de sessie niet meer kunt bijwonen op de geplande tijd, kunt u deze opnieuw plannen of annuleren via deze link: \n{{recheduleLink}}",
+        "fileName": "Live gesprekssessie",
+        "summary": "Live gesprekssessie"
+      }
     }
   }
 }

--- a/sv/px-emails.json
+++ b/sv/px-emails.json
@@ -278,7 +278,7 @@
       "privacy_policy": "Integritetspolicy",
       "privacy_policy_link": "https://www.usertesting.com/privacy-center/privacy-policy",
       "support": "Support",
-      "support_link": "https://participant-support.usertesting.com/hc/en-us",
+      "support_link": "https://participant-support.usertesting.com/hc",
       "terms_of_service": "Tjänstevillkor",
       "terms_of_service_link": "https://www.usertesting.com/privacy-center/terms-of-service-contributor"
     },
@@ -298,7 +298,7 @@
         "support_center": "Supportcentret",
         "support_center_link": "https://participant-support.usertesting.com/",
         "support_team": "supportteam",
-        "support_team_link": "https://participant-support.usertesting.com/hc/en-us/requests/new"
+        "support_team_link": "https://participant-support.usertesting.com/hc/requests/new"
       },
       "sign_off": "Tack, <br>UserTesting-teamet"
     },
@@ -309,14 +309,14 @@
     },
     "panelist_removal_email": {
       "first_body_text": "Vi har raderat ditt konto och din information från vårt system (detta e-postmeddelande är den sista kommunikationen du får från oss).",
-      "second_body_text": "Om du inte begärde detta kan det bero på en lång period av inaktivitet eller missbruk av vår plattform som resulterar i en överträdelse av {{användarvillkoren}}.",
+      "second_body_text": "Om du inte begärde detta kan det bero på en lång period av inaktivitet eller missbruk av vår plattform som resulterar i en överträdelse av <a href=\"https://www.usertesting.com/privacy-center/terms-of-service-contributor\">användarvillkoren</a>.",
       "subject": "Ditt TestKonto har raderats",
-      "third_body_text": "Om du anser att detta är ett misstag eller vill ha ytterligare information, {{kontakta oss}} eller besök vårt {{supportcenter}}.",
+      "third_body_text": "Om du anser att detta är ett misstag eller vill ha ytterligare information, <a href=\"https://participant-support.usertesting.com/hc/requests/new\">kontakta oss</a> eller besök vårt <a href=\"https://participant-support.usertesting.com/hc\">supportcenter</a>.",
       "title": "TestKonto raderat"
     },
     "participant_not_paid_email": {
       "advice": "Se till att din enhet är redo för testet nästa gång och gör ditt bästa för att ge feedback av högsta kvalitet.",
-      "best_practices": "För att undvika att detta händer igen i framtiden, läs igenom dessa {{rekommendationer om bästa praxis}} i vårt supportcenter.",
+      "best_practices": "För att undvika att detta händer igen i framtiden, läs igenom dessa <a href=\"https://participant-support.usertesting.com/hc/articles/37416051787795-Top-tips-for-a-successful-test\">rekommendationer om bästa praxis</a> i vårt supportcenter.",
       "body_text": "Vi är ledsna att meddela att ditt deltagande i testet {{projectId}} inte har godkänts och att du inte kommer att få belöningen för testet.",
       "quality_list": {
         "internet_connection": "Dålig internetanslutning.",
@@ -367,7 +367,7 @@
         "title": "Några vanliga anledningar till att man inte blir godkänd är:",
         "tol": "Att du inte uttalar dina tankar högt"
       },
-      "second_body_text": "Om du tror att det här var ett misstag, eller om du vill göra om övningen, vänligen kontakta vårt {{supportteam}}.  ",
+      "second_body_text": "Om du tror att det här var ett misstag, eller om du vill göra om övningen, vänligen kontakta vårt <a href=\"https://participant-support.usertesting.com/hc/requests/new\">supportteam</a>.",
       "subject": "Övningen har inte godkänts",
       "title": "Övningen har inte godkänts"
     },
@@ -479,6 +479,13 @@
       "body_text": "Detta är bara en vänlig påminnelse om din kommande livekonversation:",
       "subject": "Påminnelse: Din livekonversation börjar om 30 minuter!",
       "title": "Startar snart: Livekonversation"
+    },
+    "emails": {
+      "icsParticipant": {
+        "description": "Anslut till session: \n{{sessionLink}} \nKan du inte längre vara med på sammanträdet på den utsatta tiden kan du ändra schemat eller ställa in sammanträdet på följande länk:\n{{rescheduleLink}}",
+        "fileName": "Live-konversationssession",
+        "summary": "Live-konversationssession"
+      }
     }
   }
 }


### PR DESCRIPTION
### Description
The main change is to pull:
- px_emails.unified.panelist_removal_email.second_body_text
- px_emails.unified.panelist_removal_email.third_body_text
- px_emails.unified.participant_not_paid_email.best_practices
- px_emails.unified.qualification_attempt_rejected_email.second_body_text

to replace some invalid merge tokens with <a> tags with links

the rest of the changes are unrelated, it's just been a while since we pulled email tokens

### Ticket links
[RAD-44447]
