### PR TITLE
feat: new tokens to match invite specified email RAD-70415

### DIFF
--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -345,6 +345,21 @@
       "subject": "New test opportunity for you!",
       "title": "New test available"
     },
+    "participant_study_invitation_specified_email": {
+      "body": "One of our customers loved your feedback and would like your input again. Earn <strong>{{studyFee}}</strong> when you complete this new test.",
+      "button": "Book session",
+      "helpful_resources": "Helpful resources",
+      "non_tol_practice_note": "You can take this test even if you haven`t completed the practice session.",
+      "resource_live_conversation": "Live Conversation: ",
+      "resource_live_conversation_link": "https://participant-support.usertesting.com/hc/en-us/articles/37483242557075-FAQ-Live-Conversations",
+      "resource_live_conversation_link_text": "FAQ",
+      "resource_task_based": "Task-based: ",
+      "resource_task_based_link": "https://participant-support.usertesting.com/hc/en-us/articles/41323390700947-Participant-guide-How-to-give-great-feedback",
+      "resource_task_based_link_text": "How to give great feedback",
+      "subject": "New {{studyFee}} test: A customer requested you",
+      "test_details": "Test details:",
+      "title": "A customer requested you again!"
+    },
     "paypal_integration_revoked_email": {
       "body_text": "We noticed your PayPal account has been disconnected from UserTesting.\n\nTo keep receiving invites, participate in paid tests, and receive any pending payments, go to your UserTesting Home page and connect your PayPal account again.",
       "body_text_one": "We noticed your PayPal account has been disconnected from UserTesting.",
@@ -451,7 +466,8 @@
       },
       "test_type": {
         "survey": "Survey",
-        "task_based_test": "Task based"
+        "task_based_test": "Task based",
+        "live_conversation": "Live conversation"
       },
       "title": "For this test you will need:"
     },


### PR DESCRIPTION
### Description

Add tokens needed for the new invite specified participants email

### Ticket links

[RAD-70415](https://user-testing.atlassian.net/jira/software/c/projects/RAD/boards/3342?assignee=712020%3Aac68d8f6-84e9-401f-b44e-343cad674667&selectedIssue=RAD-70415)

[RAD-70415]: https://user-testing.atlassian.net/browse/RAD-70415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ