### PR TITLE
feat: add new IE11 translation key RAD-66511

### DIFF
--- a/da/px-emails.json
+++ b/da/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/de/px-emails.json
+++ b/de/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -418,6 +418,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/es-MX/px-emails.json
+++ b/es-MX/px-emails.json
@@ -251,6 +251,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/es/px-emails.json
+++ b/es/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/fr/px-emails.json
+++ b/fr/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/nl/px-emails.json
+++ b/nl/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },

--- a/sv/px-emails.json
+++ b/sv/px-emails.json
@@ -392,6 +392,7 @@
         "chrome": "Chrome",
         "edge": "Edge",
         "explorer": "Explorer",
+        "explorer_11": "Internet Explorer 11",
         "firefox": "Firefox",
         "safari": "Safari"
       },


### PR DESCRIPTION
### Description

Due to the weird way communication-service requires translation params being passed through, I think it's better to create a dedicated IE 11 translation key for this line https://github.com/UserTestingEnterprise/panel/blob/main/services/communication/src/utils/build-study-requirements-template/build-browsers-template.ts#L16 which doesn't need the version number passed through to render properly. Browser version selection is only allowed in UZ classic studies.

### Ticket links

[RAD-66511]

### Related PRs

Specify other PRs involved in this ticket/feature.

[RAD-66511]: https://user-testing.atlassian.net/browse/RAD-66511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ