### PR TITLE
feat: add UTZ reschedule email English copy RAD-74850 RAD-74851

### DIFF
--- a/en/px-emails.json
+++ b/en/px-emails.json
@@ -586,6 +586,19 @@
       "subject": "Your Live Conversation has been cancelled",
       "title": "Session cancelled"
     },
+    "time_slot_reschedule_requested_email": {
+      "body_text": "The Customer has asked if you could choose a new time for your session. Your spot is reserved until you reschedule. If you don’t choose a new time, your spot will be released to another participant.",
+      "button": "Choose new time",
+      "original_session_cancelled": "Your original session has been automatically cancelled:",
+      "subject": "Action required: Reschedule your session",
+      "title": "Request to reschedule your session"
+    },
+    "time_slot_reschedule_cancelled_email": {
+      "body_text": "The customer has cancelled the request to reschedule your Live Conversation. You’ll no longer be able to book a new time.",
+      "context_text": "Customers sometimes need to cancel the request due to a change in their testing plans.",
+      "subject": "Request to reschedule cancelled",
+      "title": "Reschedule request cancelled"
+    },
     "time_slot_email": {
       "button": "Join session",
       "ics": {


### PR DESCRIPTION
### Description

Adds English Phrase keys for the new UTZ Live Conversation reschedule panelist emails introduced in UserTestingEnterprise/panel#2518.

**Changes:**
- `utz_unified.time_slot_reschedule_requested_email` — subject, title, body, CTA, and original-session-cancelled copy
- `utz_unified.time_slot_reschedule_cancelled_email` — subject, title, body, and context copy
- Reuses existing `utz_unified.time_slot_canceled_email.apology` and `see_you_again` (not duplicated on the new keys)

English only; other locales can follow via Phrase sync.

### Ticket links

- https://user-testing.atlassian.net/browse/RAD-74850
- https://user-testing.atlassian.net/browse/RAD-74851

### Related PRs

- https://github.com/UserTestingEnterprise/panel/pull/2518

### Test plan

- [ ] Verify `en/px-emails.json` keys match template references in panel PR #2518
- [ ] Confirm apology/see-you-again resolve via `time_slot_canceled_email` after panel templates are updated
- [ ] Sync to Phrase and validate emails in DEV after panel communication migrations deploy

Made with [Cursor](https://cursor.com)